### PR TITLE
[CIA-2885] Remove after_checkout

### DIFF
--- a/.testbox/config.yml
+++ b/.testbox/config.yml
@@ -22,7 +22,6 @@ scripts:
   ls: ls
   rails: /app/bin/rails
   date: date
-  after_checkout: date
 
 feature_flags:
   upcase_titles: false


### PR DESCRIPTION
`after_checkout` is triggered via `exec` from the runner in the container. This isn't supported when we have mutlple replicas in the new single namespace parallelism strategy.

The hook is causing specs to fail.

`platform` doesn't use it https://github.com/toptal/platform/blob/master/.testbox/config.yml#L110. We should consider dropping all together. 